### PR TITLE
[MWPW-158445] Added stage domains map

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -294,11 +294,15 @@ const CONFIG = {
   // geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'business.adobe.com', 'helpx.adobe.com'],
   stageDomainsMap: {
-    'business.adobe.com': 'business.stage.adobe.com',
-    'helpx.adobe.com': 'helpx.stage.adobe.com',
-    'blog.adobe.com': 'blog.stage.adobe.com',
-    'developer.adobe.com': 'developer-stage.adobe.com',
-    'news.adobe.com': 'news.stage.adobe.com',
+    'www.stage.adobe.com': {
+      'www.adobe.com': 'origin',
+    },
+    '--dc--adobecom.hlx.live': {
+      'www.adobe.com': 'origin',
+    },
+    '--dc--adobecom.hlx.page': {
+      'www.adobe.com': 'origin',
+    },
   },
   jarvis: {
     id: 'DocumentCloudWeb1',


### PR DESCRIPTION
This PR adds the stageDomainsMap, enabling the conversion of production URLs to their stage equivalents in the stage environment.
More details about this feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

Resolves: [MWPW-158445](https://jira.corp.adobe.com/browse/MWPW-158445)

Test URLs:

Before: https://main--dc--adobecom.hlx.page?martech=off
After: https://mwpw-158445-domains-map--dc--adobecom.hlx.page?martech=off